### PR TITLE
issue# 756 Technical skills now load properly upon tab changes when updated

### DIFF
--- a/caliber/src/main/webapp/static/app/resources/js/factories/chartDataFactories/radarChartDataFactory.js
+++ b/caliber/src/main/webapp/static/app/resources/js/factories/chartDataFactories/radarChartDataFactory.js
@@ -58,23 +58,20 @@ angular.module("reportApi").factory(
 				var batchPromise = $http({
 					method : "GET",
 					url : "/all/reports/batch/" + batchId
-							+ "/overall/radar-batch-overall",
-					cache : "true"
+							+ "/overall/radar-batch-overall"
 				});
 
 				var traineePromise = $http({
 					method : "GET",
 					url : "/all/reports/trainee/" + traineeId
-							+ "/radar-trainee-overall",
-					cache : "true"
+							+ "/radar-trainee-overall"
 				});
 
 				if (Number.isInteger(week) || week > 0) {
 					traineePromise = $http({
 						method : "GET",
 						url : "/all/reports/week/" + week + "/trainee/"
-								+ traineeId + "/radar-trainee-up-to-week",
-						cache : "true"
+								+ traineeId + "/radar-trainee-up-to-week"
 					});
 				}
 


### PR DESCRIPTION
### Purpose of Pull Request
Individual Technical skills now load properly upon tab changes when assessments on Assess Batch page is updated.

### Where should the reviewer start?
Reports page, this is so the page can load initially. (As the problem was caching)
For testing you want to:
Update assessments on Assess batch page.
Look at reports page and see if it updates.
Test multiple times.

### Any background context you want to provide?
Individual Averages for technical skills were not updating after intial load of reports page. Turns out the promises for the Individual Tech Skills within the radarChartDataFactory.js (report.getTraineAndBatchSkillComparisonChart() function) were being cached. This made it so that upon reloading of the elements it would pull old information instead.

### What are the relevant stories/issues?
issue# 756

### Screenshots (if appropriate)
Before Change:
![image](https://user-images.githubusercontent.com/15112761/31626589-58e46eea-b278-11e7-92cf-d7375368cd4b.png)
![image](https://user-images.githubusercontent.com/15112761/31626600-67a1a6f0-b278-11e7-89e9-55ae9dd452bb.png)

After Change:
![image](https://user-images.githubusercontent.com/15112761/31626648-8b7ff932-b278-11e7-8b35-cc53aa312344.png)
![image](https://user-images.githubusercontent.com/15112761/31626633-7fda83cc-b278-11e7-8c38-a105131002fb.png)
