### PR TITLE
Added JsonFormat annotation to Batch.java bean for endDate and startDate

### DIFF
--- a/caliber/src/main/java/com/revature/caliber/beans/Batch.java
+++ b/caliber/src/main/java/com/revature/caliber/beans/Batch.java
@@ -29,6 +29,7 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -81,11 +82,13 @@ public class Batch implements Serializable {
 	@Column(name = "TRAINING_TYPE")
 	private TrainingType trainingType;
 
+	@JsonFormat(shape=JsonFormat.Shape.STRING, timezone="EST", pattern = "yyyy-MM-dd")
 	@NotNull
 	@Temporal(TemporalType.DATE)
 	@Column(name = "START_DATE", nullable = false)
 	private Date startDate;
 
+	@JsonFormat(shape=JsonFormat.Shape.STRING, timezone="EST", pattern = "yyyy-MM-dd")
 	@NotNull
 	@Temporal(TemporalType.DATE)
 	@Column(name = "END_DATE", nullable = false)


### PR DESCRIPTION
### Purpose of Pull Request
- Added @JsonFormat() to the Batch.java bean above endDate and startDate fields.
-- Solved the issue of the endDate and startDate being one day (specifically 5 hours) behind the entered value due to conversion from GMT to EST.

### Where should the reviewer start?
- Batch.java

### Any background context you want to provide?
- @JsonFormat annotation was taken from V2 repository and modified.

### What are the relevant stories/issues?
[Batch dates incorrect #792](https://github.com/revaturelabs/caliber/issues/792)

### Screenshots (if appropriate)
![newbatchentereddata](https://user-images.githubusercontent.com/35276088/35237421-a35f5564-ff78-11e7-97c3-ee1a690d27ab.JPG)
![newbatchtransientdata](https://user-images.githubusercontent.com/35276088/35237422-a36f81a0-ff78-11e7-8cd4-dfbda8979cbc.JPG)
![newbatchpersisteddata](https://user-images.githubusercontent.com/35276088/35237423-a3787d14-ff78-11e7-9466-130587436620.JPG)
![newbatchindatabase](https://user-images.githubusercontent.com/35276088/35237424-a3aedb8e-ff78-11e7-83bf-5f47aaf8f78a.JPG)

### Questions:
- Needs to check if the import behavior works properly, as we were unable to test this feature due to Salesforce integration.