### PR TITLE
Team bug dev - Modal fix final

### DIFF
--- a/caliber/src/main/java/com/revature/caliber/beans/Batch.java
+++ b/caliber/src/main/java/com/revature/caliber/beans/Batch.java
@@ -29,6 +29,7 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.validator.constraints.NotEmpty;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -81,11 +82,13 @@ public class Batch implements Serializable {
 	@Column(name = "TRAINING_TYPE")
 	private TrainingType trainingType;
 
+	@JsonFormat(shape=JsonFormat.Shape.STRING, timezone="EST", pattern = "yyyy-MM-dd")
 	@NotNull
 	@Temporal(TemporalType.DATE)
 	@Column(name = "START_DATE", nullable = false)
 	private Date startDate;
 
+	@JsonFormat(shape=JsonFormat.Shape.STRING, timezone="EST", pattern = "yyyy-MM-dd")
 	@NotNull
 	@Temporal(TemporalType.DATE)
 	@Column(name = "END_DATE", nullable = false)

--- a/caliber/src/main/java/com/revature/caliber/beans/Batch.java
+++ b/caliber/src/main/java/com/revature/caliber/beans/Batch.java
@@ -29,7 +29,6 @@ import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
 import org.hibernate.validator.constraints.NotEmpty;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -82,13 +81,11 @@ public class Batch implements Serializable {
 	@Column(name = "TRAINING_TYPE")
 	private TrainingType trainingType;
 
-	@JsonFormat(shape=JsonFormat.Shape.STRING, timezone="EST", pattern = "yyyy-MM-dd")
 	@NotNull
 	@Temporal(TemporalType.DATE)
 	@Column(name = "START_DATE", nullable = false)
 	private Date startDate;
 
-	@JsonFormat(shape=JsonFormat.Shape.STRING, timezone="EST", pattern = "yyyy-MM-dd")
 	@NotNull
 	@Temporal(TemporalType.DATE)
 	@Column(name = "END_DATE", nullable = false)

--- a/caliber/src/main/webapp/static/app/partials/home/qc-home.html
+++ b/caliber/src/main/webapp/static/app/partials/home/qc-home.html
@@ -55,10 +55,9 @@
 											<th class="col-sm-2 col-md-2 col-lg-2">{{label}}</th>
 											<td class="col-sm-2 col-md-2 col-lg-2"
 												ng-repeat="series in stackedBarSeries track by $index">{{stackedBarData[$index][$parent.$index]}}</td>
-												<td class="overall-batch-health"
-												ng-class="{'color-red': {{'\'' + qcOverall + '\''}} === 'Poor', 'color-yellow': {{'\'' + qcOverall + '\''}} == 'Average', 'color-green': {{'\'' + qcOverall + '\''}} == 'Good'}">
-												{{ qcOverall != "Undefined" ? qcOverall : "-"}}
-											</td>
+												<td class="overall-batch-health" ng-class="{'color-red': qcOverall[$index] === 'Poor', 'color-yellow': qcOverall[$index] === 'Average', 'color-green': qcOverall[$index] === 'Good'}">
+													{{qcOverall[$index] !== "Undefined" ? qcOverall[$index] : "-" }}
+												</td>
 										</tr>
 									</tbody>
 								</table>

--- a/caliber/src/main/webapp/static/app/partials/home/vp-home.html
+++ b/caliber/src/main/webapp/static/app/partials/home/vp-home.html
@@ -56,9 +56,8 @@
 											<th class="col-sm-2 col-md-2 col-lg-2">{{label}}</th>
 											<td class="col-sm-2 col-md-2 col-lg-2"
 												ng-repeat="series in stackedBarSeries track by $index">{{stackedBarData[$index][$parent.$index]}}</td>
-											<td class="overall-batch-health"
-												ng-class="{'color-red': {{'\'' + qcOverall + '\''}} === 'Poor', 'color-yellow': {{'\'' + qcOverall + '\''}} == 'Average', 'color-green': {{'\'' + qcOverall + '\''}} == 'Good'}">
-												{{ qcOverall != "Undefined" ? qcOverall : "-"}}
+											<td class="overall-batch-health" ng-class="{'color-red': qcOverall[$index] === 'Poor', 'color-yellow': qcOverall[$index] === 'Average', 'color-green': qcOverall[$index] === 'Good'}">
+												{{qcOverall[$index] !== "Undefined" ? qcOverall[$index] : "-" }}
 											</td>
 										</tr>
 									</tbody>

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/qcHomeController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/qcHomeController.js
@@ -117,7 +117,7 @@ angular
                                                 null,
                                                 null,
                                                 null,
-                                                $scope.displayWeek,
+                                                $scope.currentWeek,
                                                 $scope.currentBatch,
                                                 null,
                                                 "ROLE_QC",
@@ -187,7 +187,7 @@ angular
                             $scope.bnote = null;
                             for (var i = 0; i < $scope.currentBatch.trainees.length; i++) {
                                 $scope.faces.push(new Note(null, null,
-                                    null, $scope.displayWeek,
+                                    null, $scope.currentWeek,
                                     $scope.currentBatch,
                                     $scope.currentBatch.trainees[i],
                                     "ROLE_QC", "QC_TRAINEE", true));
@@ -241,6 +241,9 @@ angular
                             $scope.currentBatch.trainees.sort(compare);
                         }
 
+                        //set display week for modal header
+                        $scope.displayWeek = $scope.displayWeeksMap[$scope.currentBatch.batchId];
+                                                
                         // Set current week to first week
                         // If reports week is selected
                         if ($scope.reportCurrentWeek !== undefined
@@ -301,7 +304,7 @@ angular
                         $scope.stackedBarColors = barChartObj.colors;
                         $scope.stackedBarIds = barChartObj.id; // define scope for batch ids
                         $scope.qcOverall = barChartObj.qcOverall;
-						$scope.displayWeek = barChartObj.displayWeek;
+						$scope.displayWeeksMap = barChartObj.displayWeeksMap;
                     }
 
                     function createCurrentBatchesAverageScoreChart(data) {

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/vpHomeController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/vpHomeController.js
@@ -29,7 +29,7 @@ angular
 						NProgress.done();
 						createDefaultCharts();
 
-						
+
 					})();
 
                     // function to get overall feedback for all batches for current week
@@ -41,7 +41,7 @@ angular
                             })
                     }
 
-					// function to grab latest qc information from click
+                    // function to grab latest qc information from click
 					// event
 					$scope.onClick = function(points) {
 						if (points[0]) {
@@ -58,12 +58,12 @@ angular
 							// While loop to check if current batch id
 							// matches defined
 							// variable
-							while (batchId !== $scope.currentBatch.batchId) {
-								j += 1;
-								$scope.currentBatch = $scope.batches[j];
-								if (batchId === $scope.currentBatch.batchId) {
-									$scope.currentBatch = $scope.batches[j];
-									break;
+                            while (batchId !== $scope.currentBatch.batchId) {
+                                j += 1;
+                                $scope.currentBatch = $scope.batches[j];
+                                if (batchId === $scope.currentBatch.batchId) {
+                                    $scope.currentBatch = $scope.batches[j];
+                                    break;
 								}
 							}
 
@@ -92,107 +92,106 @@ angular
 					$scope.currentView = true;
 
 					// function to get notes
-					function getNotes() {
-						// Check if there are no weeks
-						if ($scope.displayWeek !== undefined
-								&& $scope.currentBatch !== undefined
-								&& $scope.currentBatch !== null) {
-							// Get qc batch notes for selected batch
-							caliberDelegate.qc
-									.batchNote($scope.currentBatch.batchId,
-											$scope.displayWeek)
-									.then(
-											function(notes) {
-												// If no batch note found
-												// create
-												// empty note object to be
-												// used
-												if (notes === "") {
-													$log.debug("EMPTY!");
-													$scope.bnote = new Note(
-															null,
-															null,
-															null,
-															$scope.displayWeek,
-															$scope.currentBatch,
-															null,
-															"ROLE_QC",
-															"QC_BATCH",
-															true);
-												}
-												// If note found set the
-												// note
-												// object to note content
-												// and
-												// face
-												else {
-													$scope.bnote = notes;
-													$scope.qcBatchAssess = notes.qcStatus;
-												}
-											});
-							// Get qc notes for trainees in selected batch
-							// for
-							// the week
-							caliberDelegate.qc
-									.traineeNote(
-											$scope.currentBatch.batchId,
-											$scope.displayWeek)
-									.then(
-											function(notes) {
-												$log.debug(notes);
-												// Iterate through trainees
-												for (var i = 0; i < $scope.currentBatch.trainees.length; i++) {
-													var content = null;
-													var status = null;
-													var id = null;
-													// Set note content,
-													// status
-													// and
-													// id to note in
-													// database if
-													// found
-													for (var j = 0; j < notes.length; j++) {
-														if ($scope.currentBatch.trainees[i].name === notes[j].trainee.name) {
-															content = notes[j].content;
-															status = notes[j].qcStatus;
-															id = notes[j].noteId;
-															break;
-														}
-													}
-													// Push note object into
-													// array, batch set to
-													// null
-													// for trainee note
-													// always
-													$scope.faces
-															.push(new Note(
-																	id,
-																	content,
-																	status,
-																	$scope.displayWeek,
-																	null,
-																	$scope.currentBatch.trainees[i],
-																	"ROLE_QC",
-																	"QC_TRAINEE",
-																	true));
-												}
-											});
-							// If there are no weeks
-						} else if ($scope.currentBatch !== undefined
-								&& $scope.currentBatch !== null) {
-							$scope.bnote = null;
-							for (var i = 0; i < $scope.currentBatch.trainees.length; i++) {
-								$scope.faces.push(new Note(null, null,
-										null, $scope.displayWeek,
-										$scope.currentBatch,
-										$scope.currentBatch.trainees[i],
-										"ROLE_QC", "QC_TRAINEE", true));
-							}
-						}
-					}
+                    function getNotes() {
+                        // Check if there are no weeks
+                        if ($scope.currentWeek !== undefined
+                            && $scope.currentBatch !== undefined
+                            && $scope.currentBatch !== null) {
+                            // Get qc batch notes for selected batch
+                            caliberDelegate.qc
+                                .batchNote($scope.currentBatch.batchId,
+                                    $scope.displayWeek)
+                                .then(
+                                    function(notes) {
+                                        // If no batch note found
+                                        // create
+                                        // empty note object to be
+                                        // used
+                                        if (notes === "") {
+                                            $log.debug("EMPTY!");
+                                            $scope.bnote = new Note(
+                                                null,
+                                                null,
+                                                null,
+                                                $scope.currentWeek,
+                                                $scope.currentBatch,
+                                                null,
+                                                "ROLE_QC",
+                                                "QC_BATCH",
+                                                true);
+                                        }
+                                        // If note found set the
+                                        // note
+                                        // object to note content
+                                        // and
+                                        // face
+                                        else {
+                                            $scope.bnote = notes;
+                                            $scope.qcBatchAssess = notes.qcStatus;
+                                        }
+                                    });
+                            // Get qc notes for trainees in selected batch
+                            // for
+                            // the week
+                            caliberDelegate.qc
+                                .traineeNote(
+                                    $scope.currentBatch.batchId,
+                                    $scope.displayWeek)
+                                .then(
+                                    function(notes) {
+                                        $log.debug(notes);
+                                        // Iterate through trainees
+                                        for (var i = 0; i < $scope.currentBatch.trainees.length; i++) {
+                                            var content = null;
+                                            var status = null;
+                                            var id = null;
+                                            // Set note content,
+                                            // status
+                                            // and
+                                            // id to note in
+                                            // database if
+                                            // found
+                                            for (var j = 0; j < notes.length; j++) {
+                                                if ($scope.currentBatch.trainees[i].name === notes[j].trainee.name) {
+                                                    content = notes[j].content;
+                                                    status = notes[j].qcStatus;
+                                                    id = notes[j].noteId;
+                                                    break;
+                                                }
+                                            }
+                                            // Push note object into
+                                            // array, batch set to
+                                            // null
+                                            // for trainee note
+                                            // always
+                                            $scope.faces
+                                                .push(new Note(
+                                                    id,
+                                                    content,
+                                                    status,
+                                                    $scope.currentWeek,
+                                                    null,
+                                                    $scope.currentBatch.trainees[i],
+                                                    "ROLE_QC",
+                                                    "QC_TRAINEE",
+                                                    true));
+                                        }
+                                    });
+                            // If there are no weeks
+                        } else if ($scope.currentBatch !== undefined
+                            && $scope.currentBatch !== null) {
+                            $scope.bnote = null;
+                            for (var i = 0; i < $scope.currentBatch.trainees.length; i++) {
+                                $scope.faces.push(new Note(null, null,
+                                    null, $scope.currentWeek,
+                                    $scope.currentBatch,
+                                    $scope.currentBatch.trainees[i],
+                                    "ROLE_QC", "QC_TRAINEE", true));
+                            }
+                        }
+                    }
 
-
-					// Note object
+                    // Note object
 					function Note(noteId, content, status, week, batch,
 							trainee, maxVisibility, type, qcFeedback) {
 						this.noteId = noteId;
@@ -237,6 +236,9 @@ angular
 						if ($scope.currentBatch) {
 							$scope.currentBatch.trainees.sort(compare);
 						}
+
+						//set display week for modal header
+                        $scope.displayWeek = $scope.displayWeeksMap[$scope.currentBatch.batchId];
 
 						// Set current week to first week
 						// If reports week is selected
@@ -285,7 +287,7 @@ angular
 						$scope.qcBatchAssess = null;
 						$scope.finalQCBatchNote = null;
 					}
-					
+
 					// restructured graph functions
 
 					function createAllBatchesCurrentWeekQCStats(data) {
@@ -298,7 +300,7 @@ angular
 						$scope.stackedBarColors = barChartObj.colors;
 						$scope.stackedBarIds = barChartObj.id; // define scope for batch ids
 						$scope.qcOverall = barChartObj.qcOverall;
-						$scope.displayWeek = barChartObj.displayWeek;
+						$scope.displayWeeksMap = barChartObj.displayWeeksMap;
 					}
 
 					function createCurrentBatchesAverageScoreChart(data) {
@@ -323,7 +325,7 @@ angular
 						$scope.currentPanelsLineColors = lineChartObj.colors;
 						$scope.currentPanelsDsOverride = lineChartObj.datasetOverride;
 					}
-					
+
 					function getCurrentPanelsData() {
 						chartsDelegate.line.data
 								.getCurrentPanelsLineChartData()
@@ -331,13 +333,13 @@ angular
 										function(data) {
 											$scope.panelData = data;
 											//object with 2 keys: Pass and Repanel w/ last 14 days results for each
-											createCurrentPanelsLineChart(data[0]);  
+											createCurrentPanelsLineChart(data[0]);
 											NProgress.done();
 										}, function() {
 											NProgress.done();
 										});
 					}
-					
+
 					function getCurrentBatchesAvergeScoreData() {
 						chartsDelegate.line.data
 								.getCurrentBatchesAverageScoreChartData()

--- a/caliber/src/main/webapp/static/app/resources/js/factories/chartFactories/barChartFactory.js
+++ b/caliber/src/main/webapp/static/app/resources/js/factories/chartFactories/barChartFactory.js
@@ -255,14 +255,14 @@ angular.module("charts").factory(
                 chartData.labels = [];
                 chartData.colors = [];
                 chartData.id = [];
-                chartData.qcOverall; // overall batch qcStatus for current week
-                chartData.displayWeek; // relevant week that is being displayed
+                chartData.qcOverall = []; // overall qcStatus for current week for all batches
+                chartData.displayWeeksMap = {}; // key is batch id, with value as display week
 
                 angular.forEach(data, function(batch) {
                     chartData.labels.push(batch.label);
                     chartData.id.push(batch.id);
-                    chartData.qcOverall = batch.qcOverall;
-                    chartData.displayWeek = batch.displayWeek;
+                    chartData.qcOverall.push(batch.qcOverall);
+                    chartData.displayWeeksMap[batch.id] = batch.displayWeek;
                     var i = 0;
                     angular.forEach(batch.qcStatus, function(value2, key2) {
                         // Because the qcStatuses get randomized, this if else set orders them.


### PR DESCRIPTION
### Purpose of Pull Request
**The previous pull request that was approved referencing the same issue didn't work for all case scenarios.  Added/Modified logic to match all cases.** 

- Fixed issue with overall batch status on VP home page and the QC home page not showing information from the correct batch.  Made to match the stacked graph's week.
- Fixed issue with clicking on the stacked graph creating a modal with the wrong week's trainee information.  Made to match the stacked graph's week.

### Where should the reviewer start?
- ReportingService.java
- vpHomeController.js
-- vp-home.html
- qcHomeController.js
-- qc-home.html

### Any background context you want to provide?
Altered methods involved were already tested in previous iterations.

### What are the relevant stories/issues?
[QC stacked bar graph not accurate #822](https://github.com/revaturelabs/caliber/issues/822)

### Screenshots (if appropriate)
![emptyweek_8](https://user-images.githubusercontent.com/35276088/35102130-001f8b6c-fc30-11e7-82ba-4fe171f465d6.JPG)
![vpmatchingoverall_week7](https://user-images.githubusercontent.com/35276088/35102131-0028ed4c-fc30-11e7-91cd-bba69ac225c3.JPG)
![vpmatchingmodal_week7](https://user-images.githubusercontent.com/35276088/35102132-002fab46-fc30-11e7-99f9-f1828e623960.JPG)
![qcmatchingoverall_week7](https://user-images.githubusercontent.com/35276088/35102133-00393b8e-fc30-11e7-9078-6837b6720d6f.JPG)
![qcmatchingmodal_week7](https://user-images.githubusercontent.com/35276088/35102134-004bae86-fc30-11e7-8c17-ae239879dcb4.JPG)

### Questions:
None.