### PR TITLE
Fixing phantom QC Trainees in Overall Report.

### DIFF
--- a/caliber/src/main/webapp/static/app/partials/reports.html
+++ b/caliber/src/main/webapp/static/app/partials/reports.html
@@ -297,46 +297,46 @@
 														{{item.week}}</th>
 												</tr>
 												<tr ng-repeat="traineeInfo in allQCTraineeNotesAllWeeks">
-													<td class="col-sm-3 col-md-3 col-lg-3">{{traineeInfo[0].trainee.name}}</td>
+													<td class="col-sm-3 col-md-3 col-lg-3">{{getQCTraineeName(traineeInfo)}}</td>
 													<td class="text-center " ng-repeat="status in traineeInfo">
 														<div ng-if="status.qcStatus == 'Superstar'"
-															id="{{traineeInfo[0].trainee.name}}"
+															id="{{getQCTraineeName(traineeInfo)}}"
 															value="{{status.noteId}}">
 															<a
-																ng-click="populateModal(traineeInfo[0].trainee.name,status.noteId)"
+																ng-click="populateModal(getQCTraineeName(traineeInfo),status.noteId)"
 																data-toggle="modal" data-target="#notesModal"
 																class="fa fa-star fa-2x pick mouse-over"></a>
 														</div>
 														<div ng-if="status.qcStatus == 'Good'"
-															id="{{traineeInfo[0].trainee.name}}"
+															id="{{getQCTraineeName(traineeInfo)}}"
 															value="{{status.noteId}}">
 															<a
-																ng-click="populateModal(traineeInfo[0].trainee.name,status.noteId)"
+																ng-click="populateModal(getQCTraineeName(traineeInfo),status.noteId)"
 																data-toggle="modal" data-target="#notesModal"
 																class="fa fa-smile-o fa-2x pick mouse-over"></a>
 														</div>
 														<div ng-if="status.qcStatus == 'Average'"
-															id="{{traineeInfo[0].trainee.name}}"
+															id="{{getQCTraineeName(traineeInfo)}}"
 															value="{{status.noteId}}">
 															<a
-																ng-click="populateModal(traineeInfo[0].trainee.name,status.noteId)"
+																ng-click="populateModal(getQCTraineeName(traineeInfo),status.noteId)"
 																data-toggle="modal" data-target="#notesModal"
 																class="fa fa-meh-o fa-2x pick mouse-over"></a>
 														</div>
 														<div ng-if="status.qcStatus == 'Poor'"
-															id="{{traineeInfo[0].trainee.name}}"
+															id="{{getQCTraineeName(traineeInfo)}}"
 															value="{{status.noteId}}">
 															<a
-																ng-click="populateModal(traineeInfo[0].trainee.name,status.noteId)"
+																ng-click="populateModal(getQCTraineeName(traineeInfo),status.noteId)"
 																data-toggle="modal" data-target="#notesModal"
 																class="fa fa-frown-o fa-2x pick mouse-over"></a>
 														</div>
 														<div
 															ng-if="status.qcStatus == null || status.qcStatus == 'Undefined'"
-															id="{{traineeInfo[0].trainee.name}}"
+															id="{{getQCTraineeName(traineeInfo)}}"
 															value="{{status.noteId}}">
 															<a
-																ng-click="populateModal(traineeInfo[0].trainee.name,status.noteId)"
+																ng-click="populateModal(getQCTraineeName(traineeInfo),status.noteId)"
 																data-toggle="modal" data-target="#notesModal"
 																class="fa fa-question-circle fa-2x mouse-over"></a>
 														</div>

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
@@ -314,7 +314,6 @@ angular
 
 		$scope.populateOverallModal = function populateOverallModal(value) {
 			$scope.overallNameAndNoteId = $scope.batchQCNotes;
-			console.log($scope.overallNameAndNoteId);
 			$scope.overallNameAndNoteId.forEach(function (key) {
 				if (value.noteId === key["noteId"]) {
 					$scope.overallBatchWeek = key["week"];
@@ -322,7 +321,7 @@ angular
 				}
 			})
 			if ($scope.batchNote == null) {
-				$scope.batchNote = "No available note";
+				$scope.batchNote = "No available notes.";
 				if (value.week != null) {
 					$scope.overallBatchWeek = value.week;
 				} else {

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
@@ -256,6 +256,10 @@ angular
 						}
 					})
 					
+//					for(let testIndex = 0; testIndex < $scope.allQCTraineeNotesAllWeeks.length; testIndex++) {
+//						console.log($scope.allQCTraineeNotesAllWeeks[testIndex]);
+//					}
+					
 					NProgress.done();
 
 					for (let index = 0; index < $scope.totalNumberOfWeeksInCurrentBatch; index++) {
@@ -275,7 +279,22 @@ angular
 					$log.debug("Failed to asynchronously pull data from backend. " + response);
 				}
 			)
-		};
+		}
+		
+		//Get Trainee name based on QC Trainee Notes
+		$scope.getQCTraineeName = function getQCTraineeName(traineeInfo) {
+			let traineeName;
+			traineeInfo.forEach(function(traineeNote) {
+				//Make sure QC Trainee note has the trainee object
+				
+				if(traineeNote.trainee) {
+					//Return the first encounter of trainee object name
+					traineeName = traineeNote.trainee.name;
+					return;
+				}
+			});
+			return traineeName;
+		}
 
 		//Get All Trainees (from current batch) QC Notes from all weeks 
 		function getAllQCTraineeNoteForAllWeeks() {

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
@@ -334,6 +334,7 @@ angular
 						$scope.person = $scope.getQCTraineeName(traineeNotes);
 						$scope.week = traineeNotes[i]["week"];
 						$scope.individualNote = traineeNotes[i]["content"];
+						return;
 					}
 				}
 			})

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
@@ -282,7 +282,6 @@ angular
 			let traineeName;
 			traineeInfo.forEach(function(traineeNote) {
 				//Make sure QC Trainee note has the trainee object
-				
 				if(traineeNote.trainee) {
 					//Return the first encounter of trainee object name
 					traineeName = traineeNote.trainee.name;

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
@@ -332,18 +332,14 @@ angular
 
 		}
 
-		$scope.populateModal = function populateModal(id, value) {
-			$scope.traineeNameAndNoteId = $scope.allQCTraineeNotesAllWeeks;
-			console.log($scope.traineeNameAndNoteId);
-
-			$scope.traineeNameAndNoteId.forEach(function (key) {
-				if (id === key[0]["trainee"]["name"]) {
-					for (var i = 0; key.length > i; i++) {
-						if (value === key[i]["noteId"]) {
-							$scope.person = key[0]["trainee"]["name"];
-							$scope.week = key[i]["week"];
-							$scope.individualNote = key[i]["content"];
-						}
+		$scope.populateModal = function populateModal(traineeName, noteId) {		
+			//Look for the right note
+			$scope.allQCTraineeNotesAllWeeks.forEach(function (traineeNotes) {		
+				for (var i = 0; i < traineeNotes.length; i++) {
+					if (traineeNotes[i]["noteId"] === noteId) {
+						$scope.person = $scope.getQCTraineeName(traineeNotes);
+						$scope.week = traineeNotes[i]["week"];
+						$scope.individualNote = traineeNotes[i]["content"];
 					}
 				}
 			})

--- a/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
+++ b/caliber/src/main/webapp/static/app/resources/js/controllers/allReportController.js
@@ -256,10 +256,6 @@ angular
 						}
 					})
 					
-//					for(let testIndex = 0; testIndex < $scope.allQCTraineeNotesAllWeeks.length; testIndex++) {
-//						console.log($scope.allQCTraineeNotesAllWeeks[testIndex]);
-//					}
-					
 					NProgress.done();
 
 					for (let index = 0; index < $scope.totalNumberOfWeeksInCurrentBatch; index++) {


### PR DESCRIPTION
### Purpose of Pull Request
Fixed associate names disappearing and modals not popping up in QC Overall Report.
### Where should the reviewer start?
### Any background context you want to provide?
- This logic was pulling the associate name with an index[0], which sometimes was null. I've created a function that pulls the associate name as soon as it finds a note that doesn't have the trainee as null.
- If an associate doesn't have a single QC Trainee note assigned, he won't be displayed in the report at all.
### What are the relevant stories/issues?
### Screenshots (if appropriate)
### Questions: